### PR TITLE
Revision of handling control keys.

### DIFF
--- a/ImageFlow.cpp
+++ b/ImageFlow.cpp
@@ -32,7 +32,7 @@
 */
 ImageFlow::ImageFlow()
 :  pathIsSet(false),
-   keyCode(0)
+   keyCode(-1)
 {
     intro();
 }
@@ -43,7 +43,7 @@ ImageFlow::ImageFlow()
 */
 ImageFlow::ImageFlow(const std::string &path, const int &fileIndex)
 :  pathIsSet(false),
-   keyCode(0)
+   keyCode(-1)
 {
     intro();
     (*this)(path, fileIndex);
@@ -144,160 +144,117 @@ void ImageFlow::getImage(cv::Mat &image)
         throw ImfExc(ImfExc::PATH_ERR1);
     }
 
+    keyCode = cv::waitKey(1);
+
     if (files[fileIndex].type == VIDEO)
     {
-        bool isPaused = false;
-        do
+        static bool isPaused = false;
+
+        if (SPACE_KEY)
         {
-            if (isPaused == true)
-            {
-                keyCode = cv::waitKey(0);
-                if (SPACE_KEY)
-                {
-                    keyCode = -1;
-                    break;
-                }
-            }
-            else
-            {
-                keyCode = cv::waitKey(1);
-                if (SPACE_KEY)
-                {
-                    isPaused = true;
-                    continue;
-                }
-            }
-
-            if (ESC_KEY)
-            {
-                throw ImfExc(ImfExc::EXIT);
-            }
-            else if (RIGHT_KEY)
-            {
-                if (fileIndex + 1 == files.size())
-                {
-                    throw ImfExc(ImfExc::END);
-                }
-
-                printf("Video is skipped to the next.\n");
-                setFileIndex(fileIndex + 1);
-                break;
-            }
-            else if (LEFT_KEY)
-            {
-                if (fileIndex == 0)
-                {
-                    printf("You are at the file with [0] index!\n");
-                    setFileIndex(fileIndex);
-                }
-                else
-                {
-                    printf("Video is skipped to the previous.\n");
-                    setFileIndex(fileIndex - 1);
-                }
-
-                capture.read(image);
-                return;
-            }
-            else if (UP_KEY)
-            {
-                printf("Video is repeated.\n");
-                setFileIndex(fileIndex);
-                capture.read(image);
-                return;
-            }
+            isPaused = !isPaused;
         }
-        while (isPaused == true);
-
-        capture.read(image);
-        while (image.empty())
+        else if (RIGHT_KEY)
         {
-            printf("Video is ended.\n");
-
             if (fileIndex + 1 == files.size())
             {
                 throw ImfExc(ImfExc::END);
             }
 
+            printf("Video is skipped to the next.\n");
             setFileIndex(fileIndex + 1);
+            isPaused = false;
+        }
+        else if (LEFT_KEY)
+        {
+            if (fileIndex == 0)
+            {
+                printf("You are at the file with [0] index!\n");
+                setFileIndex(fileIndex);
+            }
+            else
+            {
+                printf("Video is skipped to the previous.\n");
+                setFileIndex(fileIndex - 1);
+            }
+
+            isPaused = false;
+        }
+        else if (UP_KEY)
+        {
+            printf("Video is repeated.\n");
+            setFileIndex(fileIndex);
+            isPaused = false;
+        }
+        else if (ESC_KEY)
+        {
+            throw ImfExc(ImfExc::EXIT);
+        }
+
+        if (isPaused == false)
+        {
             capture.read(image);
+            while (image.empty())
+            {
+                printf("Video is ended.\n");
+
+                if (fileIndex + 1 == files.size())
+                {
+                    throw ImfExc(ImfExc::END);
+                }
+
+                setFileIndex(fileIndex + 1);
+                capture.read(image);
+            }
         }
     }
     else /* if (files[fileIndex].type == IMAGE) */
     {
-        while (true)
-        {
-            if (keyCode == 0)
-            {
-                keyCode = -1;
-                break;
-            }
+        static bool isFirstImage = true;
 
-            keyCode = cv::waitKey(0);
-
-            if (ESC_KEY)
-            {
-                throw ImfExc(ImfExc::EXIT);
-            }
-            else if (RIGHT_KEY)
-            {
-                if (fileIndex + 1 == files.size())
-                {
-                    throw ImfExc(ImfExc::END);
-                }
-                else
-                {
-                    printf("Image is skipped to the next.\n");
-                    setFileIndex(fileIndex + 1);
-                }
-
-                break;
-            }
-            else if (LEFT_KEY)
-            {
-                if (fileIndex == 0)
-                {
-                    printf("You are at the file with [0] index!\n");
-                    setFileIndex(fileIndex);
-                }
-                else
-                {
-                    printf("Image is skipped to the previous.\n");
-                    setFileIndex(fileIndex - 1);
-                }
-
-                capture.read(image);
-                return;
-            }
-        }
-
-        capture.read(image);
-        while (image.empty())
+        if (RIGHT_KEY)
         {
             if (fileIndex + 1 == files.size())
             {
                 throw ImfExc(ImfExc::END);
             }
+            else
+            {
+                printf("Image is skipped to the next.\n");
+                setFileIndex(fileIndex + 1);
+            }
 
-            setFileIndex(fileIndex + 1);
             capture.read(image);
         }
+        else if (LEFT_KEY)
+        {
+            if (fileIndex == 0)
+            {
+                printf("You are at the file with [0] index!\n");
+                setFileIndex(fileIndex);
+            }
+            else
+            {
+                printf("Image is skipped to the previous.\n");
+                setFileIndex(fileIndex - 1);
+            }
+
+            capture.read(image);
+        }
+        else if (ESC_KEY)
+        {
+            throw ImfExc(ImfExc::EXIT);
+        }
+        else if (isFirstImage)
+        {
+            if (image.empty() || (fileIndex > 0 && files[fileIndex - 1].type != VIDEO))
+            {
+                capture.read(image);
+            }
+
+            isFirstImage = false;
+        }
     }
-
-    return;
-}
-
-/*
-    "getKeyCode()" function puts ASCII code value of the pressed keyboard key to the passed parameter.
-*/
-void ImageFlow::getKeyCode(int &keyCode) const
-{
-    if (pathIsSet == false)
-    {
-        throw ImfExc(ImfExc::PATH_ERR1);
-    }
-
-    keyCode = this->keyCode;
 
     return;
 }

--- a/ImageFlow.cpp
+++ b/ImageFlow.cpp
@@ -50,11 +50,6 @@ ImageFlow::ImageFlow(const std::string &path, const int &fileIndex)
 }
 
 /*
-    Destructor.
-*/
-ImageFlow::~ImageFlow() {}
-
-/*
     "operator()" function lists the directory and appoints (optional) file index to start with.
 */
 void ImageFlow::operator() (const std::string &path, const int &fileIndex)
@@ -135,9 +130,10 @@ void ImageFlow::setTime(const std::string &strTime)
 
 /*
     "getImage()" function puts acquired image to the passed parameter.
+    It returns "true" if image is passed, otherwise "false".
     It also handles pressed control keys.
 */
-void ImageFlow::getImage(cv::Mat &image)
+bool ImageFlow::getImage(cv::Mat &image)
 {
     if (pathIsSet == false)
     {
@@ -206,6 +202,8 @@ void ImageFlow::getImage(cv::Mat &image)
                 setFileIndex(fileIndex + 1);
                 capture.read(image);
             }
+
+            return true;
         }
     }
     else /* if (files[fileIndex].type == IMAGE) */
@@ -225,6 +223,8 @@ void ImageFlow::getImage(cv::Mat &image)
             }
 
             capture.read(image);
+
+            return true;
         }
         else if (LEFT_KEY)
         {
@@ -240,6 +240,8 @@ void ImageFlow::getImage(cv::Mat &image)
             }
 
             capture.read(image);
+
+            return true;
         }
         else if (ESC_KEY)
         {
@@ -247,16 +249,18 @@ void ImageFlow::getImage(cv::Mat &image)
         }
         else if (isFirstImage)
         {
+            isFirstImage = false;
+
             if (image.empty() || (fileIndex > 0 && files[fileIndex - 1].type != VIDEO))
             {
                 capture.read(image);
-            }
 
-            isFirstImage = false;
+                return true;
+            }
         }
     }
 
-    return;
+    return false;
 }
 
 /*

--- a/ImageFlow.hpp
+++ b/ImageFlow.hpp
@@ -37,11 +37,6 @@ public:
     ImageFlow(const std::string &path, const int &fileIndex = 0);
 
     /*
-        Destructor.
-    */
-    ~ImageFlow();
-
-    /*
         Brackets operator assigns a new directory path and appoints (optional) file index to begin with.
     */
     void operator() (const std::string &path, const int &fileIndex = 0);
@@ -59,29 +54,24 @@ public:
     /*
         Function acquires image or video frame.
     */
-    void getImage(cv::Mat &image);
-
-    /*
-        Extended function that acquires image (video frame), type and name of the file.
-        "getImage()" function puts acquired image and its file type to the passed parameters.
-        File type parameter is "ImageFlow::file_type".
-    */
-    inline void getImage(cv::Mat &image, file_type &fileType, std::string &fileName)
-    {
-        getImage(image);
-
-        fileType = files[fileIndex].type;
-        fileName = files[fileIndex].name;
-
-        return;
-    }
+    bool getImage(cv::Mat &image);
 
     /*
         Analog of "getImage()" function.
     */
-    inline void operator>> (cv::Mat &image)
+    inline bool operator>> (cv::Mat &image)
     {
-        getImage(image);
+        return getImage(image);
+    }
+
+    /*
+        "getFileData()" function passes type and name of the currently opened file.
+        File type parameter is "ImageFlow::file_type".
+    */
+    inline void getFileInfo(file_type &fileType, std::string &fileName)
+    {
+        fileType = files[fileIndex].type;
+        fileName = files[fileIndex].name;
 
         return;
     }

--- a/ImageFlow.hpp
+++ b/ImageFlow.hpp
@@ -77,7 +77,7 @@ public:
     }
 
     /*
-        Analog of "getImage(cv::Mat &image)" function.
+        Analog of "getImage()" function.
     */
     inline void operator>> (cv::Mat &image)
     {
@@ -87,9 +87,12 @@ public:
     }
 
     /*
-        Function assigns pressed key code to the passed parameter.
+        "getKeyCode()" function returns ASCII code value of the pressed keyboard key.
     */
-    void getKeyCode(int &keyCode) const;
+    inline int getKeyCode() const
+    {
+        return keyCode;
+    }
 
 private:
     struct File
@@ -142,7 +145,7 @@ public:
     /*
         Exception message.
     */
-    virtual const char * what() const _NOEXCEPT;
+    virtual const char* what() const _NOEXCEPT;
 
 private:
     std::string message;

--- a/main.cpp
+++ b/main.cpp
@@ -17,8 +17,10 @@ int main()
 
         while (true)
         {
-            imflow >> image;
-            cv::imshow("ImageFlow", image);
+            if (imflow >> image)
+            {
+                cv::imshow("ImageFlow", image);
+            }
         }
     }
     catch (const ImfExc &imfExc)


### PR DESCRIPTION
“getImage()” function was rewritten properly. Now processing is not stuck inside the function when you pause video or try to read image files, which means “getKeyCode()” function works as expected. “getKeyCode()” function was rewritten and placed into the header file. Now it returns value instead of passing it by reference.
